### PR TITLE
Fix sending kill command on client exit

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -52,7 +52,7 @@ const process = require('process'),
         function handleExit(){
             if (pid){
                 console.log(`${settings.protocol}://${workerHost}:${settings.port}/v1/pkill/${pid}`)
-                console.log(`Send remote pkill for "${pid}"`)
+                console.log(`Send remote pkill for "${pid}"`);
                 (function(){
                     let exec = require('child_process')
                     exec.execSync(`curl ${settings.protocol}://${workerHost}:${settings.port}/v1/pkill/${pid}`, function (error, stderr) {

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -53,11 +53,12 @@ const process = require('process'),
             if (pid){
                 console.log(`${settings.protocol}://${workerHost}:${settings.port}/v1/pkill/${pid}`)
                 console.log(`Send remote pkill for "${pid}"`)
-                
-                let exec = require('child_process')
-                exec.execSync(`curl ${settings.protocol}://${workerHost}:${settings.port}/v1/pkill/${pid}`, function (error, stderr) {
-                    // we don't care about errors
-                })
+                (function(){
+                    let exec = require('child_process')
+                    exec.execSync(`curl ${settings.protocol}://${workerHost}:${settings.port}/v1/pkill/${pid}`, function (error, stderr) {
+                        // we don't care about errors
+                    })
+                })()
             }
 
             process.exit(1)

--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -53,12 +53,11 @@ const process = require('process'),
             if (pid){
                 console.log(`${settings.protocol}://${workerHost}:${settings.port}/v1/pkill/${pid}`)
                 console.log(`Send remote pkill for "${pid}"`)
-                (function(){
-                    let exec = require('child_process')
-                    exec.execSync(`curl ${settings.protocol}://${workerHost}:${settings.port}/v1/pkill/${pid}`, function (error, stderr) {
-                        // we don't care about errors
-                    })
-                })()
+                
+                let exec = require('child_process')
+                exec.execSync(`curl ${settings.protocol}://${workerHost}:${settings.port}/v1/pkill/${pid}`, function (error, stderr) {
+                    // we don't care about errors
+                })
             }
 
             process.exit(1)


### PR DESCRIPTION
When you exit form a client before the worker task finishes, the client crashes.

In these lines

```
                console.log(`${settings.protocol}://${workerHost}:${settings.port}/v1/pkill/${pid}`)
                console.log(`Send remote pkill for "${pid}"`)
                (function(){
                    let exec = require('child_process')
                    exec.execSync(`curl ${settings.protocol}://${workerHost}:${settings.port}/v1/pkill/${pid}`, function (error, stderr) {
                        // we don't care about errors
                    })
                })()
```

The brackets following the second `console.log` parses like a function call to the previous statement. This causes a crash.

An alternative fix to this is adding a `;` after `console.log(`Send remote pkill for "${pid}"`)`.